### PR TITLE
don't read csv files in binary mode, fixes crash on python 3.x

### DIFF
--- a/archive/loderunner.py
+++ b/archive/loderunner.py
@@ -166,7 +166,7 @@ def won (window):
 
 
 def create_level(num):
-	with open('level{}.csv'.format(num), 'rb') as file_data:
+	with open('level{}.csv'.format(num)) as file_data:
 		level = []
 		for row in csv.reader(file_data):
 			level.extend([int(elem) for elem in row])

--- a/characters.py
+++ b/characters.py
@@ -13,7 +13,7 @@ class Character (Drawable):
         for baddie in Baddie.baddies:
             baddie.die()
         Baddie.baddies = []
-        with open(os.path.join('levels', 'level{}.csv').format(num), 'rb') as file_data:
+        with open(os.path.join('levels', 'level{}.csv').format(num)) as file_data:
             row_num = 0
             for row in csv.reader(file_data):
                 for col, value in enumerate(row):

--- a/config.py
+++ b/config.py
@@ -13,7 +13,7 @@ class Config:
 
     @staticmethod
     def config_level(num):
-        with open(os.path.join('levels', 'level{}.csv').format(num), 'rb') as file_data:
+        with open(os.path.join('levels', 'level{}.csv').format(num)) as file_data:
             row_num = 0
             for row in csv.reader(file_data):
                 Config.LEVEL_WIDTH = len(row)

--- a/tiles.py
+++ b/tiles.py
@@ -16,7 +16,7 @@ class Tile(Drawable):
 
     @staticmethod
     def load_level(num):
-        with open(os.path.join('levels', 'level{}.csv').format(num), 'rb') as file_data:
+        with open(os.path.join('levels', 'level{}.csv').format(num)) as file_data:
             Tile.level = []
             row_num = 0
             for row in csv.reader(file_data):


### PR DESCRIPTION
The code crashes on Python 3.x because the csv files are opened in binary mode and thus returning bytes when read from, rather than strings that are expected by the code. This minor pr fixes this so we can now play using python 3 